### PR TITLE
Added WindfuryDecoration and a Junit Test for FlyingMachine

### DIFF
--- a/CardGame/src/com/chasebabbitt/cardgame/cards/AbilitiesDecorator.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/AbilitiesDecorator.java
@@ -1,5 +1,6 @@
 package com.chasebabbitt.cardgame.cards;
 
+import com.chasebabbitt.cardgame.player.Player;
 
 public abstract class AbilitiesDecorator extends Card {
 	protected Card card;
@@ -57,7 +58,7 @@ public abstract class AbilitiesDecorator extends Card {
 	}
 	//Getter method for tapped
 	public boolean tappedStatus(){
-		return card.tapped;
+		return card.tappedStatus();
 	}
 	//Setter method for tapped
 	public void exhaust(){
@@ -71,8 +72,8 @@ public abstract class AbilitiesDecorator extends Card {
 	 * Base method for comes into play abilities, passes the instruction on to the next card
 	 * Override this method to create a decoration that will have a comes into play effect.
 	 */
-	public void comesIntoPlay(){
-		card.comesIntoPlay();
+	public void comesIntoPlay(Player owner, Player opponent){
+		card.comesIntoPlay(owner, opponent);
 	}
 
 	

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/Card.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/Card.java
@@ -1,5 +1,6 @@
 package com.chasebabbitt.cardgame.cards;
 
+import com.chasebabbitt.cardgame.player.Player;
 
 public abstract class Card {
 
@@ -74,12 +75,16 @@ public abstract class Card {
 		tapped = false;
 	}
 	//Base case of a comes into play ability, does nothing
-	public void comesIntoPlay(){} //
+	public void comesIntoPlay(Player owner, Player opponent){} //
 	public void dealDamage(int damage) {
 		// TODO Auto-generated method stub
 		
 	}
 	public int getHealth() {
 		return defensepoints;
+	}
+	public void healDamage(int health) {
+		// TODO Auto-generated method stub
+		
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/HearthcloneAbilitiesDecorator.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/HearthcloneAbilitiesDecorator.java
@@ -20,10 +20,13 @@ public class HearthcloneAbilitiesDecorator extends AbilitiesDecorator{
 	}
 	
 	public void dealDamage(int damage){
-		((HearthcloneAbilitiesDecorator) card).dealDamage(damage);
+		card.dealDamage(damage);
 	}
 	public int getHealth(){
 		return card.getHealth();
+	}
+	public void healDamage(int heal){
+		card.healDamage(heal);
 	}
 
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/HearthcloneCardFactory.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/HearthcloneCardFactory.java
@@ -22,7 +22,7 @@ public class HearthcloneCardFactory implements CardFactory{
 		
 		switch(index){
 		case 0:
-			card = new DamageDecoration(new FlyingMachine());	
+			card = new WindfuryDecoration(new DamageDecoration(new FlyingMachine()));	
 			break;
 		case 1:
 			card = new DamageDecoration(new GnomereganInfantry());
@@ -47,11 +47,13 @@ public class HearthcloneCardFactory implements CardFactory{
 	@Override
 	public Card createCard(String cardname) {
 		if(cardname.equals("Ironfur Grizzly"))
-				return new TauntDecoration(new DamageDecoration(new IronfurGrizzly()));
+			return new TauntDecoration(new DamageDecoration(new IronfurGrizzly()));
 		else if(cardname.equals("Mogushan Warden"))
-				return new TauntDecoration(new DamageDecoration(new MogushanWarden()));
+			return new TauntDecoration(new DamageDecoration(new MogushanWarden()));
 		else if(cardname.equals("Silvermoon Guardian"))
-				return new DivineShieldDecoration(new DamageDecoration(new SilvermoonGuardian()));
+			return new DivineShieldDecoration(new DamageDecoration(new SilvermoonGuardian()));
+		else if(cardname.equals("Flying Machine"))
+			return new WindfuryDecoration(new DamageDecoration(new FlyingMachine()));	
 		return null;
 	}
 

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/DamageDecoration.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/DamageDecoration.java
@@ -18,4 +18,16 @@ public class DamageDecoration extends HearthcloneAbilitiesDecorator{
 	public int getHealth(){
 		return card.getDefensePoints()-damage;
 	}
+	
+	/**
+	 * Heals an amount of damage from the card
+	 * Will not heal more damage than card has health
+	 * @param heal the maximum amount that can be healed
+	 */
+	public void healDamage(int heal){
+		while(damage>0 && heal > 0){
+			damage--;
+			heal--;
+		}
+	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/FlyingMachine.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/FlyingMachine.java
@@ -9,6 +9,6 @@ public class FlyingMachine extends Card {
 		defensepoints = 4;
 		cost = 3;
 		keywords = 0; //windfury
-		
+		tapped = true;
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/FlyingMachineTest.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/FlyingMachineTest.java
@@ -1,0 +1,52 @@
+package com.chasebabbitt.cardgame.cards.hearthclone.concretecards;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import com.chasebabbitt.cardgame.cards.Card;
+import com.chasebabbitt.cardgame.cards.CardFactory;
+import com.chasebabbitt.cardgame.cards.hearthclone.HearthcloneAbilitiesDecorator;
+import com.chasebabbitt.cardgame.cards.hearthclone.HearthcloneCardFactory;
+
+public class FlyingMachineTest {
+
+	
+	CardFactory cardgenerator = new HearthcloneCardFactory();
+	Card card = cardgenerator.createCard("Flying Machine");
+	/**
+	 * Attributes test for FlyingMachine
+	 */
+	@Test
+	public void test() {
+		assertEquals(card.getKeywords(),HearthcloneAbilitiesDecorator.WINDFURY);
+		assertEquals(card.getAttackPoints(),1);
+		assertEquals(card.getDefensePoints(),4);
+		assertEquals(card.getCost(),3);
+		assertEquals(card.getName(),"Flying Machine");
+	}
+	
+	/**
+	 * Tests WindfuryDecoration and tappedStatus methods
+	 * FlyingMachine should initially be considered tapped
+	 * untap() method will be called to untap FlyingMachine
+	 * tappedStatus() should no be false
+	 * exhaust() method will now be called
+	 * A card without Windfury would be tapped at this point
+	 * but since this card has Windury tappedstatus() should still be false
+	 * exhaust() method will be called once more
+	 * tappedStatus() should now return true
+	 */
+	@Test
+	public void test2(){
+		assertEquals(card.tappedStatus(),true);
+		card.untap();
+		assertEquals(card.tappedStatus(),false);
+		card.exhaust();
+		assertEquals(card.tappedStatus(),false);
+		card.exhaust();
+		assertEquals(card.tappedStatus(),true);
+		
+	}
+
+}

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/GnomereganInfantry.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/GnomereganInfantry.java
@@ -9,5 +9,6 @@ public class GnomereganInfantry extends Card {
 		defensepoints = 4;
 		cost = 3;
 		keywords = 0; //charge && taunt
+		tapped = true;
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/IronfurGrizzly.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/IronfurGrizzly.java
@@ -8,6 +8,7 @@ public class IronfurGrizzly extends Card{
 		attackpoints = 3;
 		cost = 3;
 		defensepoints = 3;
+		tapped = true;
 	}
 
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/IronfurGrizzlyTest.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/IronfurGrizzlyTest.java
@@ -24,16 +24,43 @@ public class IronfurGrizzlyTest {
 	}
 	
 	/**
-	 *  Tests getHealth and dealDamage methods
+	 *  Tests getHealth dealDamage and healDamage methods
 	 *  Expected results: getHealth() will initially be 3
 	 *  dealDamage(2) method will be called
 	 *  getHealth() will then return 1
+	 *  healDamage(1) method will be called
+	 *  getHealth() will then return 2
+	 *  healDamage(100) method will be called
+	 *  getHealth() will then return 3
 	 */
 	@Test 
 	public void test2(){
 		assertEquals(card.getHealth(),3);
 		card.dealDamage(2);
-		assertEquals(card.getHealth(),1);		
+		assertEquals(card.getHealth(),1);
+		card.healDamage(1);
+		assertEquals(card.getHealth(),2);
+		card.healDamage(100);
+		assertEquals(card.getHealth(),3);
+		
+	}
+	/**
+	 * Tests untap and exhaust methods
+	 * 
+	 * tappedStatus() should initially return true
+	 * untap() method will then be called
+	 * tappedStatus() should now return false
+	 * exhaust() method will then be called
+	 * tappedStatus should now return true
+	 */
+	@Test
+	public void test3(){
+		assertEquals(card.tappedStatus(),true);
+		card.untap();
+		assertEquals(card.tappedStatus(),false);
+		card.exhaust();
+		assertEquals(card.tappedStatus(),true);
+		
 	}
 
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/MogushanWarden.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/MogushanWarden.java
@@ -9,5 +9,6 @@ public class MogushanWarden extends Card {
 		defensepoints = 7;
 		cost = 4;
 		keywords = 0; //taunt
+		tapped = true;
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/SilvermoonGuardian.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/SilvermoonGuardian.java
@@ -9,5 +9,6 @@ public class SilvermoonGuardian extends Card {
 		defensepoints = 3;
 		cost = 4;
 		keywords = 0; //shield
+		tapped = true;
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/StormwindKnight.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/StormwindKnight.java
@@ -9,5 +9,6 @@ public class StormwindKnight extends Card {
 		defensepoints = 5;
 		cost = 4;
 		keywords = 0; //charge
+		tapped = true;
 	}
 }

--- a/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/WindfuryDecoration.java
+++ b/CardGame/src/com/chasebabbitt/cardgame/cards/hearthclone/concretecards/WindfuryDecoration.java
@@ -1,0 +1,29 @@
+package com.chasebabbitt.cardgame.cards.hearthclone.concretecards;
+
+import com.chasebabbitt.cardgame.cards.Card;
+import com.chasebabbitt.cardgame.cards.hearthclone.HearthcloneAbilitiesDecorator;
+
+public class WindfuryDecoration extends HearthcloneAbilitiesDecorator{
+
+	public boolean windfuryattack;
+	public WindfuryDecoration(Card card) {
+		super(card);
+		windfuryattack = false;
+		keywords = HearthcloneAbilitiesDecorator.WINDFURY;
+		
+	}
+	public void untap(){
+		windfuryattack=true;
+		card.untap();
+
+	}
+	public void exhaust(){
+		if(windfuryattack==true){
+			windfuryattack = false;
+			return;
+		}
+		card.exhaust();
+	}
+	
+
+}


### PR DESCRIPTION
WindfuryDecoration should catch the exhaust method the first time it is
called on the card each turn, making it so the encapsulated card can
attack twice in a turn.